### PR TITLE
Fix compile error due to missing #include <functional>.

### DIFF
--- a/core/graph.hpp
+++ b/core/graph.hpp
@@ -31,6 +31,7 @@ Copyright (c) 2015-2016 Xiaowei Zhu, Tsinghua University
 #include <vector>
 #include <thread>
 #include <mutex>
+#include <functional>
 
 #include "core/atomic.hpp"
 #include "core/bitmap.hpp"


### PR DESCRIPTION
Related issue in #4 .

The compile error occurs with `g++-8` installed with `apt`. Not yet tested with other compilers, but `g++-8` do support C++11; add this `#include` and it compiles.